### PR TITLE
Fix: Associa labels aos inputs de rádio no seletor de tipo

### DIFF
--- a/frontend/src/components/Form/Fields/RecommendationType.js
+++ b/frontend/src/components/Form/Fields/RecommendationType.js
@@ -9,19 +9,22 @@ function RecommendationType({ onRecommendationTypeChange }) {
         <Checkbox
           type="radio"
           name="recommendationType"
+          id="singleProduct"
           value="SingleProduct"
           onChange={() => onRecommendationTypeChange('SingleProduct')}
           className="mr-2"
+          defaultChecked
         />
-        <label htmlFor="SingleProduct" className="mr-4">Produto Único</label>
+        <label htmlFor="singleProduct" className="mr-4">Produto Único</label>
         <Checkbox
           type="radio"
           name="recommendationType"
+          id="multipleProducts"
           value="MultipleProducts"
           onChange={() => onRecommendationTypeChange('MultipleProducts')}
           className="mr-2"
         />
-        <label htmlFor="MultipleProducts">Múltiplos Produtos</label>
+        <label htmlFor="multipleProducts">Múltiplos Produtos</label>
       </div>
     </div>
   );


### PR DESCRIPTION
Este Pull Request corrige um problema de acessibilidade no componente `RecommendationType`, garantindo que os `labels` textuais estejam corretamente associados aos seus respectivos `radio buttons`.

-   Adiciona `id` aos inputs do tipo rádio (`singleProduct` e `multipleProducts`).
-   Utiliza o atributo `htmlFor` nos `labels` para criar a associação correta com os inputs.
-   Adiciona a propriedade `defaultChecked` ao primeiro rádio para garantir que uma opção esteja sempre selecionada por padrão, melhorando a previsibilidade da interface.

Esta correção melhora significativamente a experiência para usuários que navegam via teclado e para aqueles que utilizam leitores de tela, permitindo que cliquem no texto para selecionar uma opção e garantindo que a associação entre texto e input seja clara.